### PR TITLE
removed Status from WorkOrder constructor

### DIFF
--- a/src/com/Processor.java
+++ b/src/com/Processor.java
@@ -1,9 +1,31 @@
 package com;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 public class Processor {
+    Map<Status, Set<WorkOrder>> workOrderMap = new HashMap<>();
+
+
     public void processWorkOrders() {
-        moveIt();
-        readIt();
+        workOrderMap.put(Status.INITIAL, new HashSet<>());
+        workOrderMap.put(Status.ASSIGNED, new HashSet<>());
+        workOrderMap.put(Status.IN_PROGRESS, new HashSet<>());
+        workOrderMap.put(Status.DONE, new HashSet<>());
+
+        try {
+            moveIt();
+            readIt();
+            Thread.sleep(5000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
     }
 
     private void moveIt() {
@@ -11,7 +33,28 @@ public class Processor {
     }
 
     private void readIt() {
-        // read the json files into WorkOrders and put in map
+        File currentDirectory = new File(".");
+        File files[] = currentDirectory.listFiles();
+
+        for (File f : files) {
+            if (f.getName().endsWith(".json")) {
+                ObjectMapper mapper = new ObjectMapper();
+                try {
+                    WorkOrder order = mapper.readValue(new File(f.getName()), WorkOrder.class);
+                    order.setStatus(Status.INITIAL);
+
+                    Set<WorkOrder> workOrderSet = workOrderMap.get(Status.INITIAL);
+                    workOrderSet.add(order);
+
+                    workOrderMap.put(Status.INITIAL, workOrderSet);
+                    f.delete();
+                    System.out.println(workOrderMap);
+
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
     }
 
     public static void main(String args[]) {

--- a/src/com/WorkOrder.java
+++ b/src/com/WorkOrder.java
@@ -12,10 +12,9 @@ public class WorkOrder {
         currentID++;
     }
 
-    public WorkOrder(String description, String senderName, Status status) {
+    public WorkOrder(String description, String senderName) {
         this.description = description;
         this.senderName = senderName;
-        this.status = status;
         id = currentID;
         currentID++;
     }


### PR DESCRIPTION
not necessary to be able to supply a status in constructor if it has none and has it set later on as it's being processed